### PR TITLE
ParticleSystem.ts基类stop方法改进。

### DIFF
--- a/particle/libsrc/particle/ParticleSystem.ts
+++ b/particle/libsrc/particle/ParticleSystem.ts
@@ -143,7 +143,6 @@ module particle {
          */
         public stop(clear:boolean = false):void {
             this.emissionTime = 0;
-            egret.Ticker.getInstance().unregister(this.update, this);
             if (clear) {
                 this.clear();
             }
@@ -183,6 +182,7 @@ module particle {
 
             if (this.numParticles == 0 && this.emissionTime == 0) {
                 this.stop();
+                egret.Ticker.getInstance().unregister(this.update, this);
                 this.dispatchEventWith(egret.Event.COMPLETE);
             }
         }


### PR DESCRIPTION
从ticker删除本实例的update放在stop里面不好，因为当前会有许多未死亡仍在运动的粒子。这样效果会非常不好。
将这句移动至update中，如果已经没有粒子了，那么再从ticker中删除update。
