### PR TITLE
firstgid小于lastgid导致contains判断不成立

### DIFF
--- a/tiled/libsrc/src/tileset/TMXTileset.ts
+++ b/tiled/libsrc/src/tileset/TMXTileset.ts
@@ -92,7 +92,7 @@ module tiled{
 			if (this._image) {
 				this._hTileCount    = ~~(this._image.width / (this._tilewidth + this._spacing));
 				this._vTileCount    = ~~(this._image.height / (this._tileheight + this._margin));
-				this._lastgid       = this._firstgid + (((this._hTileCount * this._vTileCount) - 1) || 0);
+				this._lastgid       = this._firstgid + Math.max(0,(((this._hTileCount * this._vTileCount) - 1) || 0));
 			}    
 		}
 


### PR DESCRIPTION
this._image.width < (this._tilewidth + this._spacing)且this._image.height < (this._tileheight + this._margin)的时候this._lastgid  < this._firstgid，会导致contains里面的判断问题
