### PR TITLE
IsometricRenderer非对称原点计算修复

### DIFF
--- a/tiled/libsrc/src/render/TMXIsometricRenderer.ts
+++ b/tiled/libsrc/src/render/TMXIsometricRenderer.ts
@@ -16,7 +16,7 @@ module tiled{
 			super(rows, cols, tilewidth, tileheight);
 			this._hTilewidth 	= this.tilewidth / 2;
 			this._hTileheight 	= this.tileheight / 2;
-			this._originX 		= this.rows * this._hTilewidth;
+			this._originX 		= this.cols * this._hTilewidth;
 		}
 
 		


### PR DESCRIPTION
TMXIsometricRenderer,如果地图是一个非对称的地图,那么原先通过this.rows的计算原点方式是错误的.
需要修改成通过this.cols来计算原点.